### PR TITLE
Bug fix when looking for "None" traits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poprank/rankings",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "PopRank's NFT rarity and aesthetic ranking logic",
   "publishConfig": {
     "access": "public",

--- a/src/rarity/rarity.ts
+++ b/src/rarity/rarity.ts
@@ -28,12 +28,12 @@ export const calculateTraitScore = (traitCount: number, collectionSize: number, 
  * @param trait The trait to push
  */
 const pushTraitToCollectionTraits = (collectionTraits: Record<string, TraitPreDb[]>, trait: TraitBase) => {
-    const { value, typeValue } = trait;
+    const { value, typeValue, category } = trait;
 
     if (!collectionTraits[typeValue])
         collectionTraits[typeValue] = [];
 
-    const alreadySeenTraitIndex = collectionTraits[typeValue].findIndex(t => t.value === value && t.typeValue === typeValue);
+    const alreadySeenTraitIndex = collectionTraits[typeValue].findIndex(t => t.value === value && t.typeValue === typeValue && t.category === category);
     const alreadySeenTrait = collectionTraits[typeValue][alreadySeenTraitIndex];
 
     if (alreadySeenTraitIndex === -1) {


### PR DESCRIPTION
In our OS package, we were naively looking for trait values of "none" and then ensuring that the trait category of that NFT is "None". We weren't doing this in the rankings package tho, so when i gave it NFTs from the contract, it wasn't happy for the following reason:

When going through each NFT to calculate its rarity, we check every trait type in the collection and use either that NFT's trait of that type, or, if it doesn't have a trait of that type, the "None" trait type, as defined by category:"None". The problem was, there was no category:"None", as the "None" was an actual trait in the collection so it had a category:"Trait". As we build the all-up collectionTraits object, we check for the value and the typeValue matching when we decide whether to increment the traitCount of an existing trait or add a new one. As there was a trait that had a trait type of whatever and a value of "None", we never added a "None" trait.

Normally this itself wouldn't be a problem, as ifevery* NFT correctly had every trait type defined, we'd never hit the situation where we look for category:"None". But, sappy seals fucked up their metadata a bit and one NFT has just one trait, https://opensea.io/assets/0x364c828ee171616a39897688a831c2499ad972ec/22, so when we hit this NFT and looked for the category:"None" trait for all of its missing traits, we couldn't find them.

The short term soln is just to do that trait.value.toLowerCase() === 'none', as this gives us parity, but we might need a bit more of a mature (probably heuristic-based) approach in the future. 

*I also made a small change that would at least mean we won't run into this error again by checking for category here too, to where worst case we'd just have 2 "None" traits, one of category "Trait" and one "None"